### PR TITLE
Pull upstream changes from commerce_promotion

### DIFF
--- a/commerce_fee.info.yml
+++ b/commerce_fee.info.yml
@@ -2,13 +2,9 @@ name: Commerce Fee
 type: module
 description: 'Provides a UI for managing fees.'
 package: Commerce
-# core: 8.x
+core_version_requirement: ^8.7.7 || ^9
 dependencies:
   - commerce:commerce
   - commerce:commerce_order
   - inline_entity_form:inline_entity_form
   - drupal:options
-
-version: '8.x-2.4'
-core: '8.x'
-project: 'commerce'

--- a/commerce_fee.module
+++ b/commerce_fee.module
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
+use Drupal\views\Plugin\views\field\EntityField;
 
 /**
  * Implements hook_commerce_condition_info_alter().
@@ -64,6 +65,31 @@ function template_preprocess_commerce_fee(array &$variables) {
   $variables['fee'] = [];
   foreach (Element::children($variables['elements']) as $key) {
     $variables['fee'][$key] = $variables['elements'][$key];
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Removes core's built-in formatters from views field options for
+ * fee start_date and end_date fields, since they perform timezone
+ * conversion. The "Default (Store timezone)" formatter should be used instead.
+ */
+function commerce_fee_form_views_ui_config_item_form_alter(&$form, FormStateInterface $form_state) {
+  /** @var \Drupal\views\Plugin\views\field\EntityField $handler */
+  $handler = $form_state->get('handler');
+  if ($handler instanceof EntityField && !empty($handler->definition['entity_type'])) {
+    $entity_type_id = $handler->definition['entity_type'];
+    $field_name = $handler->definition['field_name'];
+    /** @var \Drupal\Core\Entity\EntityFieldManagerInterface $field_manager */
+    $field_manager = \Drupal::service('entity_field.manager');
+    $field_definitions = $field_manager->getFieldStorageDefinitions($entity_type_id);
+    $field_definition = $field_definitions[$field_name];
+    if ($entity_type_id == 'commerce_fee' && $field_definition->getType() == 'datetime') {
+      unset($form['options']['type']['#options']['datetime_custom']);
+      unset($form['options']['type']['#options']['datetime_default']);
+      unset($form['options']['type']['#options']['datetime_plain']);
+    }
   }
 }
 

--- a/commerce_fee.post_update.php
+++ b/commerce_fee.post_update.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for Fee.
+ */
+
+/**
+ * Allows fee start and end dates to have a time component.
+ */
+function commerce_fee_post_update_1(array &$sandbox = NULL) {
+  $fee_storage = \Drupal::entityTypeManager()->getStorage('commerce_fee');
+  if (!isset($sandbox['current_count'])) {
+    $query = $fee_storage->getQuery();
+    $sandbox['total_count'] = $query->count()->execute();
+    $sandbox['current_count'] = 0;
+
+    if (empty($sandbox['total_count'])) {
+      $sandbox['#finished'] = 1;
+      return;
+    }
+  }
+
+  $query = $fee_storage->getQuery();
+  $query->range($sandbox['current_count'], 50);
+  $result = $query->execute();
+  if (empty($result)) {
+    $sandbox['#finished'] = 1;
+    return;
+  }
+
+  /** @var \Drupal\commerce_fee\Entity\Fee[] $fees */
+  $fees = $fee_storage->loadMultiple($result);
+  foreach ($fees as $fee) {
+    // Re-set each date to ensure it is stored in the updated format.
+    // Increase the end date by a day to match old inclusive loading
+    // (where an end date was valid until 23:59:59 of that day).
+    $start_date = $fee->getStartDate();
+    $end_date = $fee->getEndDate();
+    if ($end_date) {
+      $end_date = $end_date->modify('+1 day');
+    }
+    $fee->setStartDate($start_date);
+    $fee->setEndDate($end_date);
+
+    $fee->save();
+  }
+
+  $sandbox['current_count'] += 50;
+  if ($sandbox['current_count'] >= $sandbox['total_count']) {
+    $sandbox['#finished'] = 1;
+  }
+  else {
+    $sandbox['#finished'] = ($sandbox['total_count'] - $sandbox['current_count']) / $sandbox['total_count'];
+  }
+}

--- a/src/Entity/Fee.php
+++ b/src/Entity/Fee.php
@@ -5,6 +5,7 @@ namespace Drupal\commerce_fee\Entity;
 use Drupal\commerce\ConditionGroup;
 use Drupal\commerce\Entity\CommerceContentEntityBase;
 use Drupal\commerce\Plugin\Commerce\Condition\ConditionInterface;
+use Drupal\commerce\Plugin\Commerce\Condition\ParentEntityAwareInterface;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_fee\Plugin\Commerce\Fee\OrderItemFeeInterface;
 use Drupal\commerce_fee\Plugin\Commerce\Fee\FeeInterface as FeePluginInterface;
@@ -12,36 +13,42 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 
 /**
  * Defines the fee entity class.
  *
  * @ContentEntityType(
  *   id = "commerce_fee",
- *   label = @Translation("Fee"),
- *   label_collection = @Translation("Fees"),
- *   label_singular = @Translation("fee"),
- *   label_plural = @Translation("fees"),
+ *   label = @Translation("Fee", context = "Commerce"),
+ *   label_collection = @Translation("Fees", context = "Commerce"),
+ *   label_singular = @Translation("fee", context = "Commerce"),
+ *   label_plural = @Translation("fees", context = "Commerce"),
  *   label_count = @PluralTranslation(
  *     singular = "@count fee",
  *     plural = "@count fees",
+ *     context = "Commerce",
  *   ),
  *   handlers = {
  *     "event" = "Drupal\commerce_fee\Event\FeeEvent",
  *     "storage" = "Drupal\commerce_fee\FeeStorage",
  *     "access" = "Drupal\entity\EntityAccessControlHandler",
- *     "permission_provider" = "Drupal\commerce\EntityPermissionProvider",
+ *     "permission_provider" = "Drupal\entity\EntityPermissionProvider",
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "list_builder" = "Drupal\commerce_fee\FeeListBuilder",
- *     "views_data" = "Drupal\views\EntityViewsData",
+ *     "views_data" = "Drupal\commerce_fee\FeeViewsData",
  *     "form" = {
  *       "default" = "Drupal\commerce_fee\Form\FeeForm",
  *       "add" = "Drupal\commerce_fee\Form\FeeForm",
  *       "edit" = "Drupal\commerce_fee\Form\FeeForm",
+ *       "duplicate" = "Drupal\commerce_fee\Form\FeeForm",
  *       "delete" = "Drupal\Core\Entity\ContentEntityDeleteForm"
  *     },
+ *     "local_task_provider" = {
+ *       "default" = "Drupal\entity\Menu\DefaultEntityLocalTaskProvider",
+ *     },
  *     "route_provider" = {
- *       "default" = "Drupal\Core\Entity\Routing\AdminHtmlRouteProvider",
+ *       "default" = "Drupal\entity\Routing\AdminHtmlRouteProvider",
  *       "delete-multiple" = "Drupal\entity\Routing\DeleteMultipleRouteProvider",
  *     },
  *     "translation" = "Drupal\content_translation\ContentTranslationHandler"
@@ -60,6 +67,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
  *   links = {
  *     "add-form" = "/fee/add",
  *     "edit-form" = "/fee/{commerce_fee}/edit",
+ *     "duplicate-form" = "/fee/{commerce_fee}/duplicate",
  *     "delete-form" = "/fee/{commerce_fee}/delete",
  *     "delete-multiple-form" = "/admin/commerce/fees/delete",
  *     "collection" = "/admin/commerce/fees",
@@ -193,7 +201,11 @@ class Fee extends CommerceContentEntityBase implements FeeInterface {
     $conditions = [];
     foreach ($this->get('conditions') as $field_item) {
       /** @var \Drupal\commerce\Plugin\Field\FieldType\PluginItemInterface $field_item */
-      $conditions[] = $field_item->getTargetInstance();
+      $condition = $field_item->getTargetInstance();
+      if ($condition instanceof ParentEntityAwareInterface) {
+        $condition->setParentEntity($this);
+      }
+      $conditions[] = $condition;
     }
     return $conditions;
   }
@@ -232,25 +244,24 @@ class Fee extends CommerceContentEntityBase implements FeeInterface {
   /**
    * {@inheritdoc}
    */
-  public function getStartDate() {
-    // Can't use the ->date property because it resets the timezone to UTC.
-    return new DrupalDateTime($this->get('start_date')->value);
+  public function getStartDate($store_timezone = 'UTC') {
+    return new DrupalDateTime($this->get('start_date')->value, $store_timezone);
   }
 
   /**
    * {@inheritdoc}
    */
   public function setStartDate(DrupalDateTime $start_date) {
-    $this->get('start_date')->value = $start_date->format('Y-m-d');
+    $this->get('start_date')->value = $start_date->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
     return $this;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getEndDate() {
+  public function getEndDate($store_timezone = 'UTC') {
     if (!$this->get('end_date')->isEmpty()) {
-      return new DrupalDateTime($this->get('end_date')->value);
+      return new DrupalDateTime($this->get('end_date')->value, $store_timezone);
     }
   }
 
@@ -258,8 +269,10 @@ class Fee extends CommerceContentEntityBase implements FeeInterface {
    * {@inheritdoc}
    */
   public function setEndDate(DrupalDateTime $end_date = NULL) {
-    $this->get('end_date')->value = $end_date ? $end_date->format('Y-m-d') : NULL;
-    return $this;
+    $this->get('end_date')->value = NULL;
+    if ($end_date) {
+      $this->get('end_date')->value = $end_date->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
+    }
   }
 
   /**
@@ -290,12 +303,14 @@ class Fee extends CommerceContentEntityBase implements FeeInterface {
     if (!in_array($order->getStoreId(), $this->getStoreIds())) {
       return FALSE;
     }
-    $time = \Drupal::time()->getRequestTime();
-    if ($this->getStartDate()->format('U') > $time) {
+    $date = $order->getCalculationDate();
+    $store_timezone = $date->getTimezone()->getName();
+    $start_date = $this->getStartDate($store_timezone);
+    if ($start_date->format('U') > $date->format('U')) {
       return FALSE;
     }
-    $end_date = $this->getEndDate();
-    if ($end_date && $end_date->format('U') <= $time) {
+    $end_date = $this->getEndDate($store_timezone);
+    if ($end_date && $end_date->format('U') <= $date->format('U')) {
       return FALSE;
     }
 
@@ -438,10 +453,10 @@ class Fee extends CommerceContentEntityBase implements FeeInterface {
       ->setLabel(t('Start date'))
       ->setDescription(t('The date the fee becomes valid.'))
       ->setRequired(TRUE)
-      ->setSetting('datetime_type', 'date')
+      ->setSetting('datetime_type', 'datetime')
       ->setDefaultValueCallback('Drupal\commerce_fee\Entity\Fee::getDefaultStartDate')
       ->setDisplayOptions('form', [
-        'type' => 'datetime_default',
+        'type' => 'commerce_store_datetime',
         'weight' => 5,
       ]);
 
@@ -449,9 +464,10 @@ class Fee extends CommerceContentEntityBase implements FeeInterface {
       ->setLabel(t('End date'))
       ->setDescription(t('The date after which the fee is invalid.'))
       ->setRequired(FALSE)
-      ->setSetting('datetime_type', 'date')
+      ->setSetting('datetime_type', 'datetime')
+      ->setSetting('datetime_optional_label', t('Provide an end date'))
       ->setDisplayOptions('form', [
-        'type' => 'commerce_end_date',
+        'type' => 'commerce_store_datetime',
         'weight' => 6,
       ]);
 
@@ -482,21 +498,7 @@ class Fee extends CommerceContentEntityBase implements FeeInterface {
    */
   public static function getDefaultStartDate() {
     $timestamp = \Drupal::time()->getRequestTime();
-    return gmdate('Y-m-d', $timestamp);
-  }
-
-  /**
-   * Default value callback for 'end_date' base field definition.
-   *
-   * @see ::baseFieldDefinitions()
-   *
-   * @return int
-   *   The default value (date string).
-   */
-  public static function getDefaultEndDate() {
-    // Today + 1 year.
-    $timestamp = \Drupal::time()->getRequestTime();
-    return gmdate('Y-m-d', $timestamp + 31536000);
+    return gmdate(DateTimeItemInterface::DATETIME_STORAGE_FORMAT, $timestamp);
   }
 
 }

--- a/src/Entity/FeeInterface.php
+++ b/src/Entity/FeeInterface.php
@@ -140,36 +140,58 @@ interface FeeInterface extends ContentEntityInterface, EntityStoresInterface {
   public function setConditionOperator($condition_operator);
 
   /**
-   * Gets the fee start date.
+   * Gets the fee start date/time.
+   *
+   * The start date/time should always be used in the store timezone.
+   * Since the fee can belong to multiple stores, the timezone
+   * isn't known at load/save time, and is provided by the caller instead.
+   *
+   * Note that the returned date/time value is the same in any timezone,
+   * the "2019-10-17 10:00" stored value is returned as "2019-10-17 10:00 CET"
+   * for "Europe/Berlin" and "2019-10-17 10:00 ET" for "America/New_York".
+   *
+   * @param string $store_timezone
+   *   The store timezone. E.g. "Europe/Berlin".
    *
    * @return \Drupal\Core\Datetime\DrupalDateTime
-   *   The fee start date.
+   *   The promotion start date/time.
    */
-  public function getStartDate();
+  public function getStartDate($store_timezone = 'UTC');
 
   /**
-   * Sets the fee start date.
+   * Sets the fee start date/time.
    *
    * @param \Drupal\Core\Datetime\DrupalDateTime $start_date
-   *   The fee start date.
+   *   The fee start date/time.
    *
    * @return $this
    */
   public function setStartDate(DrupalDateTime $start_date);
 
   /**
-   * Gets the fee end date.
+   * Gets the fee end date/time.
+   *
+   * The end date/time should always be used in the store timezone.
+   * Since the promotion can belong to multiple stores, the timezone
+   * isn't known at load/save time, and is provided by the caller instead.
+   *
+   * Note that the returned date/time value is the same in any timezone,
+   * the "2019-10-17 11:00" stored value is returned as "2019-10-17 11:00 CET"
+   * for "Europe/Berlin" and "2019-10-17 11:00 ET" for "America/New_York".
+   *
+   * @param string $store_timezone
+   *   The store timezone. E.g. "Europe/Berlin".
    *
    * @return \Drupal\Core\Datetime\DrupalDateTime
-   *   The fee end date.
+   *   The fee end date/time.
    */
-  public function getEndDate();
+  public function getEndDate($store_timezone = 'UTC');
 
   /**
-   * Sets the fee end date.
+   * Sets the fee end date/time.
    *
    * @param \Drupal\Core\Datetime\DrupalDateTime $end_date
-   *   The fee end date.
+   *   The fee end date/time.
    *
    * @return $this
    */

--- a/src/Entity/FeeInterface.php
+++ b/src/Entity/FeeInterface.php
@@ -16,6 +16,8 @@ interface FeeInterface extends ContentEntityInterface, EntityStoresInterface {
   /**
    * Gets the fee name.
    *
+   * This name is admin-facing.
+   *
    * @return string
    *   The fee name.
    */
@@ -30,6 +32,27 @@ interface FeeInterface extends ContentEntityInterface, EntityStoresInterface {
    * @return $this
    */
   public function setName($name);
+
+  /**
+   * Gets the fee display name.
+   *
+   * This name is user-facing.
+   * Shown in the order total summary.
+   *
+   * @return string
+   *   The fee display name. If empty, use t('Fee').
+   */
+  public function getDisplayName();
+
+  /**
+   * Sets the fee display name.
+   *
+   * @param string $display_name
+   *   The fee display name.
+   *
+   * @return $this
+   */
+  public function setDisplayName($display_name);
 
   /**
    * Gets the fee description.

--- a/src/FeeListBuilder.php
+++ b/src/FeeListBuilder.php
@@ -43,8 +43,8 @@ class FeeListBuilder extends EntityListBuilder {
     if (!$entity->isEnabled()) {
       $row['name'] .= ' (' . $this->t('Disabled') . ')';
     }
-    $row['start_date'] = $entity->getStartDate()->format('M jS Y');
-    $row['end_date'] = $entity->getEndDate() ? $entity->getEndDate()->format('M jS Y') : '—';
+    $row['start_date'] = $entity->getStartDate()->format('M jS Y H:i:s');
+    $row['end_date'] = $entity->getEndDate() ? $entity->getEndDate()->format('M jS Y H:i:s') : '—';
 
     return $row + parent::buildRow($entity);
   }

--- a/src/FeeStorage.php
+++ b/src/FeeStorage.php
@@ -13,6 +13,7 @@ use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 

--- a/src/FeeStorage.php
+++ b/src/FeeStorage.php
@@ -8,8 +8,10 @@ use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Cache\MemoryCache\MemoryCacheInterface;
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -33,21 +35,25 @@ class FeeStorage extends CommerceContentEntityStorage implements FeeStorageInter
    *   The entity type definition.
    * @param \Drupal\Core\Database\Connection $database
    *   The database connection to be used.
-   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
-   *   The entity manager.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache
    *   The cache backend to be used.
    * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
    *   The language manager.
    * @param \Drupal\Core\Cache\MemoryCache\MemoryCacheInterface $memory_cache
    *   The memory cache.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle info.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *   The event dispatcher.
    * @param \Drupal\Component\Datetime\TimeInterface $time
    *   The time.
    */
-  public function __construct(EntityTypeInterface $entity_type, Connection $database, EntityManagerInterface $entity_manager, CacheBackendInterface $cache, LanguageManagerInterface $language_manager, MemoryCacheInterface $memory_cache, EventDispatcherInterface $event_dispatcher, TimeInterface $time) {
-    parent::__construct($entity_type, $database, $entity_manager, $cache, $language_manager, $memory_cache, $event_dispatcher);
+  public function __construct(EntityTypeInterface $entity_type, Connection $database, EntityFieldManagerInterface $entity_field_manager, CacheBackendInterface $cache, LanguageManagerInterface $language_manager, MemoryCacheInterface $memory_cache, EntityTypeBundleInfoInterface $entity_type_bundle_info, EntityTypeManagerInterface $entity_type_manager, EventDispatcherInterface $event_dispatcher, TimeInterface $time) {
+    parent::__construct($entity_type, $database, $entity_field_manager, $cache, $language_manager, $memory_cache, $entity_type_bundle_info, $entity_type_manager, $event_dispatcher);
 
     $this->time = $time;
   }
@@ -59,10 +65,12 @@ class FeeStorage extends CommerceContentEntityStorage implements FeeStorageInter
     return new static(
       $entity_type,
       $container->get('database'),
-      $container->get('entity.manager'),
+      $container->get('entity_field.manager'),
       $container->get('cache.entity'),
       $container->get('language_manager'),
       $container->get('entity.memory_cache'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('entity_type.manager'),
       $container->get('event_dispatcher'),
       $container->get('datetime.time')
     );
@@ -72,15 +80,16 @@ class FeeStorage extends CommerceContentEntityStorage implements FeeStorageInter
    * {@inheritdoc}
    */
   public function loadAvailable(OrderInterface $order) {
-    $today = gmdate('Y-m-d', $this->time->getRequestTime());
+    $date = $order->getCalculationDate()->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
+
     $query = $this->getQuery();
     $or_condition = $query->orConditionGroup()
-      ->condition('end_date', $today, '>=')
+      ->condition('end_date', $date, '>')
       ->notExists('end_date');
     $query
       ->condition('stores', [$order->getStoreId()], 'IN')
       ->condition('order_types', [$order->bundle()], 'IN')
-      ->condition('start_date', $today, '<=')
+      ->condition('start_date', $date, '<=')
       ->condition('status', TRUE)
       ->condition($or_condition);
     $result = $query->execute();

--- a/src/FeeTranslationHandler.php
+++ b/src/FeeTranslationHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\commerce_fee;
+
+use Drupal\content_translation\ContentTranslationHandler;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Defines the translation handler for fees.
+ */
+class FeeTranslationHandler extends ContentTranslationHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function entityFormAlter(array &$form, FormStateInterface $form_state, EntityInterface $entity) {
+    parent::entityFormAlter($form, $form_state, $entity);
+
+    if (isset($form['content_translation'])) {
+      $form['content_translation']['status']['#access'] = FALSE;
+      $form['content_translation']['uid']['#access'] = FALSE;
+      $form['content_translation']['created']['#access'] = FALSE;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function entityFormEntityBuild($entity_type, EntityInterface $entity, array $form, FormStateInterface $form_state) {
+    if ($form_state->hasValue('content_translation')) {
+      $translation = &$form_state->getValue('content_translation');
+      /** @var \Drupal\commerce_fee\Entity\FeeInterface $entity */
+      $translation['status'] = $entity->isEnabled();
+      $translation['uid'] = 0;
+    }
+    parent::entityFormEntityBuild($entity_type, $entity, $form, $form_state);
+  }
+
+}

--- a/src/FeeViewsData.php
+++ b/src/FeeViewsData.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\commerce_fee;
+
+use Drupal\commerce\CommerceEntityViewsData;
+use Drupal\Core\Field\FieldDefinitionInterface;
+
+/**
+ * Provides views data for fees.
+ */
+class FeeViewsData extends CommerceEntityViewsData {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function processViewsDataForDatetime($table, FieldDefinitionInterface $field_definition, array &$views_field, $field_column_name) {
+    parent::processViewsDataForDatetime($table, $field_definition, $views_field, $field_column_name);
+
+    // Fee date/time fields are always used in the store timezone.
+    if ($field_column_name == 'value') {
+      $views_field['field']['default_formatter'] = 'commerce_store_datetime';
+      $views_field['filter']['id'] = 'commerce_store_datetime';
+    }
+  }
+
+}

--- a/src/Form/FeeForm.php
+++ b/src/Form/FeeForm.php
@@ -5,18 +5,21 @@ namespace Drupal\commerce_fee\Form;
 use Drupal\Core\Entity\ContentEntityForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\entity\Form\EntityDuplicateFormTrait;
 
 /**
  * Defines the fee add/edit form.
  */
 class FeeForm extends ContentEntityForm {
 
+  use EntityDuplicateFormTrait;
+
   /**
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     // Skip building the form if there are no available stores.
-    $store_query = $this->entityManager->getStorage('commerce_store')->getQuery();
+    $store_query = $this->entityTypeManager->getStorage('commerce_store')->getQuery();
     if ($store_query->count()->execute() == 0) {
       $link = Link::createFromRoute('Add a new store.', 'entity.commerce_store.add_page');
       $form['warning'] = [
@@ -32,10 +35,8 @@ class FeeForm extends ContentEntityForm {
    * {@inheritdoc}
    */
   public function form(array $form, FormStateInterface $form_state) {
-    /* @var \Drupal\commerce_fee\Entity\Fee $fee */
-    $fee = $this->entity;
-
     $form = parent::form($form, $form_state);
+
     $form['#tree'] = TRUE;
     $form['#theme'] = ['commerce_fee_form'];
     $form['#attached']['library'][] = 'commerce_fee/form';
@@ -67,7 +68,6 @@ class FeeForm extends ContentEntityForm {
       'start_date' => 'date_details',
       'end_date' => 'date_details',
     ];
-
     foreach ($field_details_mapping as $field => $group) {
       if (isset($form[$field])) {
         $form[$field]['#group'] = $group;
@@ -82,7 +82,8 @@ class FeeForm extends ContentEntityForm {
    */
   public function save(array $form, FormStateInterface $form_state) {
     $this->entity->save();
-    drupal_set_message($this->t('Saved the %label fee.', ['%label' => $this->entity->label()]));
+    $this->postSave($this->entity, $this->operation);
+    $this->messenger()->addMessage($this->t('Saved the %label fee.', ['%label' => $this->entity->label()]));
     $form_state->setRedirect('entity.commerce_fee.collection');
   }
 

--- a/src/Form/FeeForm.php
+++ b/src/Form/FeeForm.php
@@ -38,6 +38,15 @@ class FeeForm extends ContentEntityForm {
     $form = parent::form($form, $form_state);
 
     $form['#tree'] = TRUE;
+
+    $translating = !$this->isDefaultFormLangcode($form_state);
+    $hide_non_translatable_fields = $this->entity->isDefaultTranslationAffectedOnly();
+    // The second column is empty when translating with non-translatable
+    // fields hidden, so there's no reason to add it.
+    if ($translating && $hide_non_translatable_fields) {
+      return $form;
+    }
+
     $form['#theme'] = ['commerce_fee_form'];
     $form['#attached']['library'][] = 'commerce_fee/form';
 

--- a/src/Plugin/Commerce/Fee/OrderFixedAmount.php
+++ b/src/Plugin/Commerce/Fee/OrderFixedAmount.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\commerce_fee\Plugin\Commerce\Fee;
 
-use Drupal\commerce_fee\Entity\FeeInterface;
 use Drupal\commerce_order\Adjustment;
+use Drupal\commerce_fee\Entity\FeeInterface;
 use Drupal\Core\Entity\EntityInterface;
 
 /**

--- a/src/Plugin/Commerce/Fee/OrderFixedAmount.php
+++ b/src/Plugin/Commerce/Fee/OrderFixedAmount.php
@@ -28,9 +28,9 @@ class OrderFixedAmount extends OrderFeeBase {
     $this->assertEntity($entity);
     /** @var \Drupal\commerce_order\Entity\OrderInterface $order */
     $order = $entity;
-    $subtotal_price = $order->getSubTotalPrice();
+    $total_price = $order->getTotalPrice();
     $amount = $this->getAmount();
-    if ($subtotal_price->getCurrencyCode() != $amount->getCurrencyCode()) {
+    if ($total_price->getCurrencyCode() != $amount->getCurrencyCode()) {
       return;
     }
     // Split the amount between order items.
@@ -40,8 +40,7 @@ class OrderFixedAmount extends OrderFeeBase {
       if (isset($amounts[$order_item->id()])) {
         $order_item->addAdjustment(new Adjustment([
           'type' => 'fee',
-          // @todo Change to label from UI when added in #2770731.
-          'label' => t('Fee'),
+          'label' => $fee->getDisplayName() ?: $this->t('Fee'),
           'amount' => $amounts[$order_item->id()],
           'source_id' => $fee->id(),
         ]));

--- a/src/Plugin/Commerce/Fee/OrderItemFeeBase.php
+++ b/src/Plugin/Commerce/Fee/OrderItemFeeBase.php
@@ -76,4 +76,11 @@ abstract class OrderItemFeeBase extends FeeBase implements OrderItemFeeInterface
     return $this;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getConditionOperator() {
+    return 'OR';
+  }
+
 }

--- a/src/Plugin/Commerce/Fee/OrderItemFeeInterface.php
+++ b/src/Plugin/Commerce/Fee/OrderItemFeeInterface.php
@@ -28,4 +28,12 @@ interface OrderItemFeeInterface extends FeeInterface {
    */
   public function setConditions(array $conditions);
 
+  /**
+   * Gets the condition operator.
+   *
+   * @return string
+   *   The condition operator. Possible values: AND, OR.
+   */
+  public function getConditionOperator();
+
 }

--- a/src/Plugin/Commerce/Fee/OrderItemFixedAmount.php
+++ b/src/Plugin/Commerce/Fee/OrderItemFixedAmount.php
@@ -26,9 +26,9 @@ class OrderItemFixedAmount extends OrderItemFeeBase {
     $this->assertEntity($entity);
     /** @var \Drupal\commerce_order\Entity\OrderItemInterface $order_item */
     $order_item = $entity;
-    $total_price = $order_item->getTotalPrice();
+    $adjusted_total_price = $order_item->getAdjustedTotalPrice(['fee']);
     $amount = $this->getAmount();
-    if ($total_price->getCurrencyCode() != $amount->getCurrencyCode()) {
+    if ($adjusted_total_price->getCurrencyCode() != $amount->getCurrencyCode()) {
       return;
     }
     $adjustment_amount = $amount->multiply($order_item->getQuantity());
@@ -36,8 +36,7 @@ class OrderItemFixedAmount extends OrderItemFeeBase {
 
     $order_item->addAdjustment(new Adjustment([
       'type' => 'fee',
-      // @todo Change to label from UI when added in #2770731.
-      'label' => t('Fee'),
+      'label' => $fee->getDisplayName() ?: $this->t('Fee'),
       'amount' => $adjustment_amount,
       'source_id' => $fee->id(),
     ]));

--- a/src/Plugin/Commerce/Fee/OrderItemPercentage.php
+++ b/src/Plugin/Commerce/Fee/OrderItemPercentage.php
@@ -32,8 +32,7 @@ class OrderItemPercentage extends OrderItemFeeBase {
 
     $order_item->addAdjustment(new Adjustment([
       'type' => 'fee',
-      // @todo Change to label from UI when added in #2770731.
-      'label' => t('Fee'),
+      'label' => $fee->getDisplayName() ?: $this->t('Fee'),
       'amount' => $adjustment_amount,
       'percentage' => $percentage,
       'source_id' => $fee->id(),

--- a/src/Plugin/Commerce/Fee/OrderPercentage.php
+++ b/src/Plugin/Commerce/Fee/OrderPercentage.php
@@ -38,8 +38,7 @@ class OrderPercentage extends OrderFeeBase {
       if (isset($amounts[$order_item->id()])) {
         $order_item->addAdjustment(new Adjustment([
           'type' => 'fee',
-          // @todo Change to label from UI when added in #2770731.
-          'label' => t('Fee'),
+          'label' => $promotion->getDisplayName() ?: $this->t('Fee'),
           'amount' => $amounts[$order_item->id()],
           'percentage' => $percentage,
           'source_id' => $fee->id(),

--- a/src/Plugin/Commerce/Fee/OrderPercentage.php
+++ b/src/Plugin/Commerce/Fee/OrderPercentage.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\commerce_fee\Plugin\Commerce\Fee;
 
-use Drupal\commerce_fee\Entity\FeeInterface;
 use Drupal\commerce_order\Adjustment;
+use Drupal\commerce_fee\Entity\FeeInterface;
 use Drupal\Core\Entity\EntityInterface;
 
 /**

--- a/tests/src/Kernel/Entity/FeeTest.php
+++ b/tests/src/Kernel/Entity/FeeTest.php
@@ -59,6 +59,8 @@ class FeeTest extends CommerceKernelTestBase {
   /**
    * @covers ::getName
    * @covers ::setName
+   * @covers ::getDisplayName
+   * @covers ::setDisplayName
    * @covers ::getDescription
    * @covers ::setDescription
    * @covers ::getOrderTypes
@@ -88,6 +90,9 @@ class FeeTest extends CommerceKernelTestBase {
 
     $fee->setName('My Fee');
     $this->assertEquals('My Fee', $fee->getName());
+
+    $fee->setDisplayName('50%');
+    $this->assertEquals('50%', $fee->getDisplayName());
 
     $fee->setDescription('My Fee Description');
     $this->assertEquals('My Fee Description', $fee->getDescription());

--- a/tests/src/Kernel/FeeCartTest.php
+++ b/tests/src/Kernel/FeeCartTest.php
@@ -6,31 +6,14 @@ use Drupal\commerce_fee\Entity\Fee;
 use Drupal\commerce_price\Price;
 use Drupal\commerce_product\Entity\Product;
 use Drupal\commerce_product\Entity\ProductVariation;
-use Drupal\Tests\commerce_cart\Kernel\CartManagerTestTrait;
-use Drupal\Tests\commerce\Kernel\CommerceKernelTestBase;
+use Drupal\Tests\commerce_cart\Kernel\CartKernelTestBase;
 
 /**
  * Tests the integration between fees and carts.
  *
  * @group commerce
  */
-class FeeCartTest extends CommerceKernelTestBase {
-
-  use CartManagerTestTrait;
-
-  /**
-   * The cart manager.
-   *
-   * @var \Drupal\commerce_cart\CartManager
-   */
-  protected $cartManager;
-
-  /**
-   * The cart provider.
-   *
-   * @var \Drupal\commerce_cart\CartProvider
-   */
-  protected $cartProvider;
+class FeeCartTest extends CartKernelTestBase {
 
   /**
    * Modules to enable.
@@ -71,8 +54,6 @@ class FeeCartTest extends CommerceKernelTestBase {
    * Tests adding a product with a fee to the cart.
    */
   public function testFeeCart() {
-    $this->installCommerceCart();
-
     $variation = ProductVariation::create([
       'type' => 'default',
       'sku' => strtolower($this->randomMachineName()),

--- a/tests/src/Kernel/FeeOrderProcessorTest.php
+++ b/tests/src/Kernel/FeeOrderProcessorTest.php
@@ -64,7 +64,7 @@ class FeeOrderProcessorTest extends CommerceKernelTestBase {
 
     $this->order = Order::create([
       'type' => 'default',
-      'state' => 'completed',
+      'state' => 'draft',
       'mail' => 'test@example.com',
       'ip_address' => '127.0.0.1',
       'order_number' => '6',

--- a/tests/src/Kernel/FeeStorageTest.php
+++ b/tests/src/Kernel/FeeStorageTest.php
@@ -99,6 +99,16 @@ class FeeStorageTest extends CommerceKernelTestBase {
       'name' => 'Fee 1',
       'order_types' => [$this->orderType],
       'stores' => [$this->store->id()],
+      'fee' => [
+        'target_plugin_id' => 'order_fixed_amount',
+        'target_plugin_configuration' => [
+          'amount' => [
+            'number' => '25.00',
+            'currency_code' => 'USD',
+          ],
+        ],
+      ],
+      'start_date' => '2019-11-15T10:14:00',
       'status' => TRUE,
     ]);
     $this->assertEquals(SAVED_NEW, $fee1->save());
@@ -109,6 +119,13 @@ class FeeStorageTest extends CommerceKernelTestBase {
       'name' => 'Fee 2',
       'order_types' => [$this->orderType],
       'stores' => [$this->store->id()],
+      'fee' => [
+        'target_plugin_id' => 'order_percentage',
+        'target_plugin_configuration' => [
+          'percentage' => '0.20',
+        ],
+      ],
+      'start_date' => '2019-01-01T00:00:00',
       'status' => FALSE,
     ]);
     $this->assertEquals(SAVED_NEW, $fee2->save());
@@ -117,8 +134,14 @@ class FeeStorageTest extends CommerceKernelTestBase {
       'name' => 'Fee 3',
       'order_types' => [$this->orderType],
       'stores' => [$this->store->id()],
+      'fee' => [
+        'target_plugin_id' => 'order_percentage',
+        'target_plugin_configuration' => [
+          'percentage' => '0.30',
+        ],
+      ],
+      'start_date' => '2014-01-01T00:00:00',
       'status' => TRUE,
-      'start_date' => '2014-01-01T20:00:00Z',
     ]);
     $this->assertEquals(SAVED_NEW, $fee3->save());
     // Start in 1 week, end in 1 year. Enabled.
@@ -127,8 +150,15 @@ class FeeStorageTest extends CommerceKernelTestBase {
       'order_types' => [$this->orderType],
       'stores' => [$this->store->id()],
       'status' => TRUE,
-      'start_date' => gmdate('Y-m-d', time() + 604800),
-      'end_date' => gmdate('Y-m-d', time() + 31536000),
+      'fee' => [
+        'target_plugin_id' => 'order_percentage',
+        'target_plugin_configuration' => [
+          'percentage' => '0.40',
+        ],
+      ],
+      'start_date' => '2019-01-01T00:00:00',
+      'end_date' => '2019-11-15T10:14:00',
+      'status' => TRUE,
     ]);
     $this->assertEquals(SAVED_NEW, $fee4->save());
 


### PR DESCRIPTION
The constructor for `CommerceContentEntityStorage` changed, and `PromotionStorage::loadAvailable()` got some date improvements.

Link to Drupal.org issue: https://www.drupal.org/project/commerce/issues/2903716